### PR TITLE
Ignore scheduled tasks in "by priority" view

### DIFF
--- a/org-custom-agenda-views.el
+++ b/org-custom-agenda-views.el
@@ -336,19 +336,24 @@
                   (org-agenda-write-buffer-name "List Review"))
                  "~/org___agenda-all-todo-entries.html") t)
 
-  (add-to-list 'org-agenda-custom-commands
-               '("rap" "All Tasks (grouped by Priority)"
-                 ((tags-todo "PRIORITY={A}"
-                             ((org-agenda-overriding-header "HIGH")))
-                  (tags-todo "PRIORITY={B}"
-                             ((org-agenda-overriding-header "MEDIUM")))
-                  (tags-todo "PRIORITY=\"\""
-                             ((org-agenda-overriding-header "NONE"))) ; = Medium.
-                  (tags-todo "PRIORITY={C}"
-                             ((org-agenda-overriding-header "LOW")))
-                  (todo "DONE|CANX"
-                        ((org-agenda-overriding-header "COMPLETED")
-                         (org-agenda-sorting-strategy '(priority-down)))))) t)
+    (add-to-list 'org-agenda-custom-commands
+                 '("p" "All Tasks (grouped by Priority)"
+                    ((tags-todo "PRIORITY={A}"
+                               ((org-agenda-overriding-header "HIGH")
+                                (org-agenda-skip-function '(org-agenda-skip-entry-if 'deadline 'scheduled))))
+                    (tags-todo "PRIORITY={B}"
+                               ((org-agenda-overriding-header "MEDIUM")
+                                (org-agenda-skip-function '(org-agenda-skip-entry-if 'deadline 'scheduled))))
+                    (tags-todo "PRIORITY=\"\""
+                               ((org-agenda-overriding-header "NONE")
+                                (org-agenda-skip-function '(org-agenda-skip-entry-if 'deadline 'scheduled))))
+                    (tags-todo "PRIORITY={C}"
+                               ((org-agenda-overriding-header "LOW")
+                                (org-agenda-skip-function '(org-agenda-skip-entry-if 'deadline 'scheduled))))
+                    (todo "DONE|CANX"
+                          ((org-agenda-overriding-header "COMPLETED")
+                           (org-agenda-sorting-strategy '(priority-down)))))) t)
+
 
   (add-to-list 'org-agenda-custom-commands
                '("rt" . "Timesheet...") t)


### PR DESCRIPTION
The `All Tasks (grouped by Priority)` is cleaner without scheduled tasks on it.  Scheduled tasks show up on the agenda and elsewhere, so they're not needed here.